### PR TITLE
Update version of official schema

### DIFF
--- a/ps-as/README.md
+++ b/ps-as/README.md
@@ -54,8 +54,7 @@ The following prefixes are used to refer to the corresponding XML namespaces in 
 
 Prefix         | Namespace
 -------------- | -------------------------------------------------
-ps3            | urn:x-inspire:specification:gmlas:ProtectedSites:3.0
-ps             | http://inspire.ec.europa.eu/schemas/ps/4.0
+ps             | http://inspire.ec.europa.eu/schemas/ps/5.0
 base           | http://inspire.ec.europa.eu/schemas/base/3.3
 gml            | http://www.opengis.net/gml/3.2
 wfs            | http://www.opengis.net/wfs/2.0

--- a/ps-gml/official-schema-validation.md
+++ b/ps-gml/official-schema-validation.md
@@ -8,7 +8,7 @@
 
 **Test method**
 
-* Validate each document against the latest INSPIRE official schema(s): https://inspire.ec.europa.eu/schemas/ps/4.0/ProtectedSites.xsd, using strict XML schema validation.
+* Validate each document against the latest INSPIRE official schema(s): https://inspire.ec.europa.eu/schemas/ps/5.0/ProtectedSites.xsd, using strict XML schema validation.
 
 **Reference(s)**: 
 


### PR DESCRIPTION
The version of the official schema(s) was updated according to the latest application schema release (https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1).

See the related validator issue for reference: https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1027